### PR TITLE
Update codebase to Swift 4

### DIFF
--- a/Witness/EventStream.swift
+++ b/Witness/EventStream.swift
@@ -28,11 +28,8 @@ class EventStream {
         self.paths = paths
         self.changeHandler = changeHandler
         
-        func callBack (_ stream: OpaquePointer, clientCallbackInfo: UnsafeMutableRawPointer?, numEvents: Int, eventPaths: UnsafeMutableRawPointer, eventFlags: UnsafePointer<FSEventStreamEventFlags>?, eventIDs: UnsafePointer<FSEventStreamEventId>?) -> Void {
-            guard let eventFlags = eventFlags else {
-                return
-            }
-            
+        func callBack(stream: ConstFSEventStreamRef, clientCallbackInfo: UnsafeMutableRawPointer?, numEvents: Int, eventPaths: UnsafeMutableRawPointer, eventFlags: UnsafePointer<FSEventStreamEventFlags>, eventIDs: UnsafePointer<FSEventStreamEventId>) {
+
             let eventStream = unsafeBitCast(clientCallbackInfo, to: EventStream.self)
             let paths = unsafeBitCast(eventPaths, to: NSArray.self)
             


### PR DESCRIPTION
The typealias `FSEventStreamCallback`, which is used by both `FSEventStreamCreate(_:)` and `FSEventStreamCreateRelativeToDevice`, updated the last 2 parameters to not be optional. Thereby, removing the need for the guard statement inside of the `callback(_:)` function. 

Please review :)